### PR TITLE
Fix TypeError: JAX does not support string indexing; got idx=('value',)

### DIFF
--- a/convert_from_jax.py
+++ b/convert_from_jax.py
@@ -9,46 +9,46 @@ from transformers import AutoTokenizer
 
 def convert_weights(weights, dump_weights):
     # vision encoder weights
-    weights['vision_patch_embedding_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['embedding']['kernel']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_patch_embedding_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['embedding']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_position_embedding'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['pos_embedding']['value'], dtype=torch.bfloat16, device="cpu").squeeze())
+    weights['vision_patch_embedding_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['embedding']['kernel'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_patch_embedding_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['embedding']['bias'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_position_embedding'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['pos_embedding'], dtype=torch.bfloat16, device="cpu").squeeze())
 
     vision_attn_qkv_w = torch.cat([
-        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['kernel']['value'], dtype=torch.bfloat16, device="cpu").flatten(2),
-        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['kernel']['value'], dtype=torch.bfloat16, device="cpu").flatten(2),
-        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['kernel']['value'], dtype=torch.bfloat16, device="cpu").flatten(2),
+        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['kernel'], dtype=torch.bfloat16, device="cpu").flatten(2),
+        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['kernel'], dtype=torch.bfloat16, device="cpu").flatten(2),
+        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['kernel'], dtype=torch.bfloat16, device="cpu").flatten(2),
     ], dim=2)
     weights['vision_attn_qkv_w'].copy_(vision_attn_qkv_w)
     vision_attn_qkv_b = torch.cat([
-        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['bias']['value'], dtype=torch.bfloat16, device="cpu").flatten(1),
-        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['bias']['value'], dtype=torch.bfloat16, device="cpu").flatten(1),
-        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['bias']['value'], dtype=torch.bfloat16, device="cpu").flatten(1),
+        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['bias'], dtype=torch.bfloat16, device="cpu").flatten(1),
+        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['bias'], dtype=torch.bfloat16, device="cpu").flatten(1),
+        torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['bias'], dtype=torch.bfloat16, device="cpu").flatten(1),
     ], dim=1)
     weights['vision_attn_qkv_b'].copy_(vision_attn_qkv_b)
-    weights['vision_attn_o_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['kernel']['value'], dtype=torch.bfloat16, device="cpu").flatten(1, -2))
-    weights['vision_attn_o_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['bias']['value'], dtype=torch.bfloat16, device="cpu").flatten(1))
+    weights['vision_attn_o_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['kernel'], dtype=torch.bfloat16, device="cpu").flatten(1, -2))
+    weights['vision_attn_o_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['bias'], dtype=torch.bfloat16, device="cpu").flatten(1))
 
-    weights['vision_ffn_up_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['kernel']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_ffn_up_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_ffn_down_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['kernel']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_ffn_down_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_ffn_up_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['kernel'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_ffn_up_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['bias'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_ffn_down_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['kernel'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_ffn_down_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['bias'], dtype=torch.bfloat16, device="cpu"))
 
-    weights['vision_pre_attn_norm_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['scale']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_pre_attn_norm_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_pre_ffn_norm_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['scale']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_pre_ffn_norm_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_final_norm_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoder_norm']['scale']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['vision_final_norm_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoder_norm']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_pre_attn_norm_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['scale'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_pre_attn_norm_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['bias'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_pre_ffn_norm_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['scale'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_pre_ffn_norm_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['bias'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_final_norm_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoder_norm']['scale'], dtype=torch.bfloat16, device="cpu"))
+    weights['vision_final_norm_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['Transformer']['encoder_norm']['bias'], dtype=torch.bfloat16, device="cpu"))
 
     # encoder weights
-    weights['encoder_multi_modal_projector_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['head']['kernel']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['encoder_multi_modal_projector_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['head']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
-    w_scale = dump_weights['PaliGemma']['llm']['layers']['pre_attention_norm']['scale']['value'].astype('float32')
+    weights['encoder_multi_modal_projector_w'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['head']['kernel'], dtype=torch.bfloat16, device="cpu"))
+    weights['encoder_multi_modal_projector_b'].copy_(torch.tensor(dump_weights['PaliGemma']['img']['head']['bias'], dtype=torch.bfloat16, device="cpu"))
+    w_scale = dump_weights['PaliGemma']['llm']['layers']['pre_attention_norm']['scale'].astype('float32')
 
-    w_q = dump_weights['PaliGemma']['llm']['layers']['attn']['q_einsum']['w']['value'].astype('float32')
+    w_q = dump_weights['PaliGemma']['llm']['layers']['attn']['q_einsum']['w'].astype('float32')
     w_q = w_q.transpose((0, 2, 1, 3)).reshape((18, 2048, 8 * 256))
-    w_k = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum']['w']['value'][:, 0, 0].astype('float32')
-    w_v = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum']['w']['value'][:, 1, 0].astype('float32')
+    w_k = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum']['w'][:, 0, 0].astype('float32')
+    w_v = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum']['w'][:, 1, 0].astype('float32')
     w_q *= (1 + w_scale[:, :, None])
     w_k *= (1 + w_scale[:, :, None])
     w_v *= (1 + w_scale[:, :, None])
@@ -59,16 +59,16 @@ def convert_weights(weights, dump_weights):
         np.concatenate([w_q, w_k, w_v], axis = 2),
         dtype=torch.bfloat16, device="cpu"
     )
-    w_attn_o = dump_weights['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['w']['value'].reshape((18, 8 * 256, 2048)).astype('float32')
+    w_attn_o = dump_weights['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['w'].reshape((18, 8 * 256, 2048)).astype('float32')
     weights['encoder_attn_o_w'] = torch.tensor(
         w_attn_o,
         dtype=torch.bfloat16, device="cpu"
     )
     
-    rms_norm = dump_weights['PaliGemma']['llm']['layers']['pre_ffw_norm']['scale']['value'].astype('float32')
-    w_gate = dump_weights['PaliGemma']['llm']['layers']['mlp']['gating_einsum']['value'][:, 0].astype('float32')
-    w_up = dump_weights['PaliGemma']['llm']['layers']['mlp']['gating_einsum']['value'][:, 1].astype('float32')
-    w_down = dump_weights['PaliGemma']['llm']['layers']['mlp']['linear']['value'].astype('float32')
+    rms_norm = dump_weights['PaliGemma']['llm']['layers']['pre_ffw_norm']['scale'].astype('float32')
+    w_gate = dump_weights['PaliGemma']['llm']['layers']['mlp']['gating_einsum'][:, 0].astype('float32')
+    w_up = dump_weights['PaliGemma']['llm']['layers']['mlp']['gating_einsum'][:, 1].astype('float32')
+    w_down = dump_weights['PaliGemma']['llm']['layers']['mlp']['linear'].astype('float32')
     w_gate *= (1 + rms_norm[:, :, None])
     w_up *= (1 + rms_norm[:, :, None])
 
@@ -86,12 +86,12 @@ def convert_weights(weights, dump_weights):
     )
 
     # decoder weights
-    w_scale = dump_weights['PaliGemma']['llm']['layers']['pre_attention_norm_1']['scale']['value'].astype('float32')
+    w_scale = dump_weights['PaliGemma']['llm']['layers']['pre_attention_norm_1']['scale'].astype('float32')
 
-    w_q = dump_weights['PaliGemma']['llm']['layers']['attn']['q_einsum_1']['w']['value'].astype('float32')
+    w_q = dump_weights['PaliGemma']['llm']['layers']['attn']['q_einsum_1']['w'].astype('float32')
     w_q = w_q.transpose((0, 2, 1, 3)).reshape((18, 1024, 8 * 256))
-    w_k = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum_1']['w']['value'][:, 0, 0].astype('float32')
-    w_v = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum_1']['w']['value'][:, 1, 0].astype('float32')
+    w_k = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum_1']['w'][:, 0, 0].astype('float32')
+    w_v = dump_weights['PaliGemma']['llm']['layers']['attn']['kv_einsum_1']['w'][:, 1, 0].astype('float32')
     w_q *= (1 + w_scale[:, :, None])
     w_k *= (1 + w_scale[:, :, None])
     w_v *= (1 + w_scale[:, :, None])
@@ -102,16 +102,16 @@ def convert_weights(weights, dump_weights):
         dtype=torch.bfloat16, device="cpu"
     )
 
-    w_attn_o = dump_weights['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum_1']['w']['value'].reshape((18, 8 * 256, 1024)).astype('float32')
+    w_attn_o = dump_weights['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum_1']['w'].reshape((18, 8 * 256, 1024)).astype('float32')
     weights['decoder_attn_o_w'] = torch.tensor(
         w_attn_o,
         dtype=torch.bfloat16, device="cpu"
     )
 
-    rms_norm = dump_weights['PaliGemma']['llm']['layers']['pre_ffw_norm_1']['scale']['value'].astype('float32')
-    w_gate = dump_weights['PaliGemma']['llm']['layers']['mlp_1']['gating_einsum']['value'][:, 0].astype('float32')
-    w_up = dump_weights['PaliGemma']['llm']['layers']['mlp_1']['gating_einsum']['value'][:, 1].astype('float32')
-    w_down = dump_weights['PaliGemma']['llm']['layers']['mlp_1']['linear']['value'].astype('float32')
+    rms_norm = dump_weights['PaliGemma']['llm']['layers']['pre_ffw_norm_1']['scale'].astype('float32')
+    w_gate = dump_weights['PaliGemma']['llm']['layers']['mlp_1']['gating_einsum'][:, 0].astype('float32')
+    w_up = dump_weights['PaliGemma']['llm']['layers']['mlp_1']['gating_einsum'][:, 1].astype('float32')
+    w_down = dump_weights['PaliGemma']['llm']['layers']['mlp_1']['linear'].astype('float32')
     w_gate *= (1 + rms_norm[:, :, None])
     w_up *= (1 + rms_norm[:, :, None])
     weights['decoder_ffn_gate_w'] = torch.tensor(
@@ -127,8 +127,8 @@ def convert_weights(weights, dump_weights):
         dtype=torch.bfloat16, device="cpu"
     )
 
-    weights['decoder_state_in_proj_w'].copy_(torch.tensor(dump_weights['state_proj']['kernel']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['decoder_state_in_proj_b'].copy_(torch.tensor(dump_weights['state_proj']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
+    weights['decoder_state_in_proj_w'].copy_(torch.tensor(dump_weights['state_proj']['kernel'], dtype=torch.bfloat16, device="cpu"))
+    weights['decoder_state_in_proj_b'].copy_(torch.tensor(dump_weights['state_proj']['bias'], dtype=torch.bfloat16, device="cpu"))
 
     def _create_sinusoidal_pos_embedding(time: torch.tensor, dimension: int, min_period: float, max_period: float, device="cpu"):
         dtype = torch.float32
@@ -141,35 +141,35 @@ def convert_weights(weights, dump_weights):
 
     n_decode_steps = 10
     mlp_in_weight_action = torch.tensor(
-        dump_weights['action_time_mlp_in']['kernel']['value'][:1024, :],
+        dump_weights['action_time_mlp_in']['kernel'][:1024, :],
         dtype=torch.bfloat16, device="cpu"
     )
     mlp_in_weight_time = torch.tensor(
-        dump_weights['action_time_mlp_in']['kernel']['value'][1024:, :],
+        dump_weights['action_time_mlp_in']['kernel'][1024:, :],
         dtype=torch.bfloat16, device="cpu"
     )
     action_time_mlp_in_b = torch.tensor(
-        dump_weights['action_time_mlp_in']['bias']['value'],
+        dump_weights['action_time_mlp_in']['bias'],
         dtype=torch.bfloat16, device="cpu"
     )
     action_in_proj_w = torch.tensor(
-        dump_weights['action_in_proj']['kernel']['value'],
+        dump_weights['action_in_proj']['kernel'],
         dtype=torch.bfloat16, device="cpu"
     )
     action_in_proj_b = torch.tensor(
-        dump_weights['action_in_proj']['bias']['value'],
+        dump_weights['action_in_proj']['bias'],
         dtype=torch.bfloat16, device="cpu"
     )
     decoder_action_fused_out_proj_w = torch.tensor(
-        dump_weights['action_out_proj']['kernel']['value'],
+        dump_weights['action_out_proj']['kernel'],
         dtype=torch.bfloat16, device="cpu"
     )
     decoder_action_fused_out_proj_b = torch.tensor(
-        dump_weights['action_out_proj']['bias']['value'],
+        dump_weights['action_out_proj']['bias'],
         dtype=torch.bfloat16, device="cpu"
     )
     final_norm_scale = torch.tensor(
-        dump_weights['PaliGemma']['llm']['final_norm_1']['scale']['value'],
+        dump_weights['PaliGemma']['llm']['final_norm_1']['scale'],
         dtype=torch.bfloat16, device="cpu"
     )
 
@@ -186,8 +186,8 @@ def convert_weights(weights, dump_weights):
             action_bias_contrib + time_contrib + action_time_mlp_in_b
         ).to(torch.bfloat16)
     
-    weights['decoder_action_mlp_w'].copy_(torch.tensor(dump_weights['action_time_mlp_out']['kernel']['value'], dtype=torch.bfloat16, device="cpu"))
-    weights['decoder_action_mlp_b'].copy_(torch.tensor(dump_weights['action_time_mlp_out']['bias']['value'], dtype=torch.bfloat16, device="cpu"))
+    weights['decoder_action_mlp_w'].copy_(torch.tensor(dump_weights['action_time_mlp_out']['kernel'], dtype=torch.bfloat16, device="cpu"))
+    weights['decoder_action_mlp_b'].copy_(torch.tensor(dump_weights['action_time_mlp_out']['bias'], dtype=torch.bfloat16, device="cpu"))
 
     decoder_action_fused_out_proj_w *= (1 + final_norm_scale[:, None])
     decoder_action_fused_out_proj_w *= -0.1
@@ -257,7 +257,7 @@ if __name__ == "__main__":
     
     num_views = 2
     dump_weights = load_jax_weights(args.jax_path)
-    embedding_weight = dump_weights['PaliGemma']['llm']['embedder']['input_embedding']['value']
+    embedding_weight = dump_weights['PaliGemma']['llm']['embedder']['input_embedding']
     language_embeds, prompt_len = prepare_prompt(args.prompt, embedding_weight, args.tokenizer_path)
 
     weights = {


### PR DESCRIPTION
When running 
```
python3 convert_from_jax.py    --jax_path ~/.cache/openpi-assets/checkpoints/pi0_base/  --output converted_checkpoint.pkl   --prompt "your task prompt" --tokenizer_path google/paligemma-3b-pt-224
```

I got this error.
```
Traceback (most recent call last):
  File "realtime-vla/convert_from_jax.py", line 260, in <module>
    embedding_weight = dump_weights['PaliGemma']['llm']['embedder']['input_embedding']['value']
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "openpi/.venv/lib/python3.11/site-packages/jax/_src/array.py", line 382, in __getitem__
    return indexing.rewriting_take(self, idx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "openpi/.venv/lib/python3.11/site-packages/jax/_src/numpy/indexing.py", line 632, in rewriting_take
    treedef, static_idx, dynamic_idx = split_index_for_jit(idx, arr.shape)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "openpi/.venv/lib/python3.11/site-packages/jax/_src/numpy/indexing.py", line 720, in split_index_for_jit
    raise TypeError(f"JAX does not support string indexing; got {idx=}")
TypeError: JAX does not support string indexing; got idx=('value',)
```

Removing `['value']` was sufficient to fix this.

I'm on jax version 0.5.3. Putting this here in case anyone else runs into an issue